### PR TITLE
Update README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -132,24 +132,7 @@ Install drivers with these commands:
 ~~~
 $git clone https://github.com/respeaker/seeed-voicecard
 $cd seeed-voicecard
-$sudo ./install.sh 2mic
-~~~
-
-Edit the ALSA configuration:
-
-~~~
-$cp asound_2mic.conf ~/.asoundrc
-$cd
-$nano ~/.asoundrc
-~~~
-
-Change the two occurrences of **"hw:0,0"** to **"hw:1,0"**.
-
-Save (CTRL-O) and exit (CTRL-X).
-
-Reboot:
-
-~~~
+$sudo ./install.sh
 $sudo reboot
 ~~~
 


### PR DESCRIPTION
ReSpeaker v0.3 no longer requires to specifically install it with the 2mic parameter (https://github.com/respeaker/seeed-voicecard#install-seeed-voicecard.). Alsa sound config is also copied automatically while running the ./install.sh so there is no need of renaming "hw:0,0" to "hw:1,0".